### PR TITLE
AuthenticationsControllerのdestroyアクションを作成

### DIFF
--- a/backend/app/controllers/authentications_controller.rb
+++ b/backend/app/controllers/authentications_controller.rb
@@ -1,4 +1,7 @@
 class AuthenticationsController < ApplicationController
+  before_action :certificated, only: %i[destroy]
+
+  # ログイン
   def create
     # フロントから認可コードを取得
     code = params[:code]
@@ -44,4 +47,16 @@ class AuthenticationsController < ApplicationController
     user_access_digest = @user.convert_digest
     render status: :created, json: { user_id: @user.id, user_access_digest: user_access_digest }
   end
+
+  # ログアウト
+  def destroy
+    delete_tokens
+    redner status: :no_content
+  end
+
+  private
+    def delete_tokens(user)
+      user.user_access_digest = ""
+      user.refresh_token = ""
+    end
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -4,6 +4,6 @@ Rails.application.routes.draw do
     resources :games, only: %i[index]
     resources :clips, only: %i[index show]
     post "/clips", to: "clips#create_many"
-    resources :authentications, only: %i[create]
+    resources :authentications, only: %i[create destroy]
   end
 end


### PR DESCRIPTION
## 実施タスク
AuthenticationsControllerのdestroyアクションを作成

## 実施内容
- destroyアクションを作成

## その他 / 備考
どちらかというと、フロント側でuser_access_digestとuser_idをcookiesから削除する方が大事
