### PR TITLE
PlaylistsControllerの作成

### DIFF
--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::API
   include HttpDealer
 
-  # 認証：digestが存在するとき、user_idを取得
+  # 認証：userIdとuserAccessDigestの組が正しいときに、@current_userを作成
   def certificated
     if user_id = request.headers["userId"]
       digest = request.headers["userAccessDigest"]
@@ -12,5 +12,15 @@ class ApplicationController < ActionController::API
         @current_user = user
       end
     end
+  end
+
+  # 認可：@current_userが存在しないときに、Unauthorizedを返す
+  def authorized
+    render status: :unauthorized, json: { error: "Unauthorized" } if !@current_user
+  end
+
+  # ログインユーザーとプレイリストの保持者が同じ人物かを確かめる
+  def correct_user(playlist)
+    render status: :forbidden, json: { error: "Forbidden" } unless @current_user == playlist.user
   end
 end

--- a/backend/app/controllers/concerns/search.rb
+++ b/backend/app/controllers/concerns/search.rb
@@ -1,0 +1,19 @@
+module Search
+  # AND検索
+  def and_search(input, target, model)
+    keywords = input.split(/[[:blank:]]+/)
+
+    # 初期値
+    elements = []
+
+    # AND検索
+    keywords.each_with_index do |keyword, i|
+      if i == 0
+        elements = model.where("#{target} LIKE ?", "%#{keyword}%")
+      else
+        elements = elements & model.where("#{target} LIKE ?", "%#{keyword}%")
+      end
+    end
+    elements
+  end
+end

--- a/backend/app/controllers/playlists_controller.rb
+++ b/backend/app/controllers/playlists_controller.rb
@@ -1,0 +1,146 @@
+class PlaylistsController < ApplicationController
+  include Search
+  before_action :certificated, except: %i[index show]
+  before_action :authorized, except: %i[index show]
+  before_action :input_playlist, except: %i[index create]
+
+  def index
+    playlists = fileter_playlists
+    playlists = apply_term(playlists)
+    apply_order(playlists)
+    render status: :ok, json: @playlists, each_serializer: PlaylistSerializer, meta: { elementsCount: @playlists_all_page.size, limit: 20 }, adapter: :json
+  end
+
+  def show
+    render status: :ok, json: @playlist
+  end
+
+  def create
+    @playlist = @current_user.playlists.build(title: params[:title])
+    if @playlist.save
+      render status: :created
+    else
+      render status: :unprocessable_entity
+    end
+  end
+
+  def update
+    correct_user(@playlist) and return
+    if @playlist.update(title: params[:title])
+      render status: :created
+    else
+      render status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    correct_user(@playlist) and return
+    @playlist.destroy
+    render status: :no_content
+  end
+
+  def add_clip
+    correct_user(@playlist) and return
+    @clip = Clip.find_by(slug: params[:clip_id])
+    @playlist.add(@clip)
+    render status: :created
+  end
+
+  def remove_clip
+    correct_user(@playlist) and return
+    @clip = Clip.find_by(slug: params[:clip_id])
+    @playlist.remove(@clip)
+    render status: :no_content
+  end
+
+  def order_clips
+  end
+
+  private
+    def input_playlist
+      @playlist = Playlist.find_by(slug: params[:id])
+    end
+
+    def fileter_playlists
+      # すべてを対象にソート
+      if !params[:all].nil?
+        and_search(params[:all], "search_keywords", Playlist)
+
+      # creatorでソート
+      elsif !params[:creator].nil?
+        Playlist.joins(:user).where(users: { display_name: params[:creator] })
+
+      # titleでソート
+      elsif !params[:title].nil?
+        and_search(params[:title], "title", Playlist)
+
+      # 指定なし(すべてのプレイリスト)
+      else
+        Playlist.all
+      end
+    end
+
+    def apply_term(playlists)
+      # 1日
+      if params[:term] == "day"
+        playlists = playlists.where(created_at: Time.zone.today.beginning_of_day..Time.zone.today.end_of_day)
+
+      # 1週間
+      elsif params[:term] == "week"
+        playlists = playlists.where(created_at: 1.week.ago.beginning_of_day..Time.zone.today.end_of_day)
+
+      # 1カ月
+      elsif params[:term] == "month"
+        playlists = playlists.where(created_at: 1.month.ago.beginning_of_day..Time.zone.today.end_of_day)
+
+      # 1年
+      elsif params[:term] == "year"
+        playlists = playlists.where(created_at: 1.year.ago.beginning_of_day..Time.zone.today.end_of_day)
+
+      # 指定なし(全期間)
+      else
+        # pass
+      end
+      playlists
+    end
+
+    def apply_order(playlists)
+      # お気に入り登録が多い順
+      if params[:order] == "fav_desc"
+        playlists = playlists.sort_by { |playlist| playlist.favorites.length }.reverse
+        ids = playlists.map(&:id)
+        playlists = Playlist.in_order_of(:id, ids)
+
+      # お気に入り登録が少ない順
+      elsif params[:order] == "fav_asc"
+        playlists = playlists.sort_by { |playlist| playlist.favorites.length }
+        ids = playlists.map(&:id)
+        playlists = Playlist.in_order_of(:id, ids)
+
+      # 日付の新しい順
+      elsif params[:order] == "date_desc"
+        playlists = playlists.sort_by { |playlist| playlist.created_at }.reverse
+        ids = playlists.map(&:id)
+        playlists = Playlist.in_order_of(:id, ids)
+
+      # 日付の古い順
+      elsif params[:order] == "date_asc"
+        playlists = playlists.sort_by { |playlist| playlist.created_at }
+        ids = playlists.map(&:id)
+        playlists = Playlist.in_order_of(:id, ids)
+
+      # 指定なし(お気に入り登録が多い順)
+      else
+        playlists = playlists.sort_by { |playlist| playlist.favorites.length }.reverse
+        ids = playlists.map(&:id)
+        playlists = Playlist.in_order_of(:id, ids)
+      end
+
+      @playlists_all_page = playlists
+      if playlists.empty?
+        @playlists = playlists
+      else
+        @playlists = playlists.paginate(page: params[:page], per_page: 20)
+      end
+    end
+end

--- a/backend/app/models/clip.rb
+++ b/backend/app/models/clip.rb
@@ -9,6 +9,9 @@ class Clip < ApplicationRecord
   has_many :playlist_clips, dependent: :destroy
   has_many :playlists, through: :playlist_clips
 
+  # アクション
+  before_save { self.search_keywords = "#{self.title} #{self.broadcaster.display_name} #{self.game.name}" }
+
   # バリデーション
   validates :slug, presence: true, uniqueness: true
 end

--- a/backend/app/models/playlist.rb
+++ b/backend/app/models/playlist.rb
@@ -12,6 +12,7 @@ class Playlist < ApplicationRecord
 
   # アクション
   before_create { self.slug = SecureRandom.uuid }
+  before_save { self.search_keywords = "#{self.title} #{self.user.display_name}" }
 
   # バリデーション
 

--- a/backend/app/serializers/clip_serializer.rb
+++ b/backend/app/serializers/clip_serializer.rb
@@ -1,5 +1,5 @@
 class ClipSerializer < ActiveModel::Serializer
-  attributes %i[slug broadcaster_name creator_name game_name game_image language title view_count clip_created_at thumbnail_url duration]
+  attributes %i[slug broadcaster_name creator_name game_name game_image language title view_count clip_created_at thumbnail_url duration search_keywords]
 end
 
 def game_name

--- a/backend/app/serializers/playlist_serializer.rb
+++ b/backend/app/serializers/playlist_serializer.rb
@@ -1,0 +1,23 @@
+class PlaylistSerializer < ActiveModel::Serializer
+  attributes %i[slug title creator_name first_clip_thumbnail_url clips_count favorites_count created_at search_keywords]
+
+  def creator_name
+    object.user.display_name
+  end
+
+  def first_clip_thumbnail_url
+    if object.clips.count == 0
+      "" # TODO: 真っ黒な画像用意しておく。
+    else
+      object.clips.first.thumbnail_url
+    end
+  end
+
+  def clips_count
+    object.clips.count
+  end
+
+  def favorites_count
+    object.fav_users.count
+  end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -2,6 +2,13 @@ Rails.application.routes.draw do
   scope :api do
     resources :broadcasters, only: %i[index create]
     resources :games, only: %i[index]
+    resources :playlists, only: %i[index show create update destroy] do
+      member do
+        post "/cilips/:clip_id", to: "playlists#add_clip", as: "clip"
+        delete "/cilips/:clip_id", to: "playlists#remove_clip"
+        put "/cilips", to: "playlists#order_clips", as: "clips"
+      end
+    end
     resources :clips, only: %i[index show]
     post "/clips", to: "clips#create_many"
     resources :authentications, only: %i[create destroy]

--- a/backend/db/migrate/20240308124002_create_clips.rb
+++ b/backend/db/migrate/20240308124002_create_clips.rb
@@ -13,6 +13,7 @@ class CreateClips < ActiveRecord::Migration[7.0]
       t.string :thumbnail_url
       t.float :duration
       t.integer :view_count
+      t.string :search_keywords
       t.integer :order, null: false, default: 1
 
       t.timestamps

--- a/backend/db/migrate/20240308124020_create_playlists.rb
+++ b/backend/db/migrate/20240308124020_create_playlists.rb
@@ -4,6 +4,7 @@ class CreatePlaylists < ActiveRecord::Migration[7.0]
       t.string :slug, unique: true
       t.string :title
       t.references :user, null: false, foreign_key: true
+      t.string :search_keywords
 
       t.timestamps
     end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -32,6 +32,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_08_124059) do
     t.string "thumbnail_url"
     t.float "duration"
     t.integer "view_count"
+    t.string "search_keywords"
     t.integer "order", default: 1, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -70,6 +71,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_08_124059) do
     t.string "slug"
     t.string "title"
     t.bigint "user_id", null: false
+    t.string "search_keywords"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_playlists_on_user_id"

--- a/backend/spec/factories/playlists.rb
+++ b/backend/spec/factories/playlists.rb
@@ -1,0 +1,17 @@
+FactoryBot.define do
+  factory :playlist do
+    trait :my_playlist do
+      id { 1 }
+      slug { "twitch_id_1" }
+      title { "マイプレイリスト" }
+      user_id { 1 }
+    end
+
+    trait :other_playlist do
+      id { 2 }
+      slug { "twitch_id_2" }
+      title { "誰かのプレイリスト" }
+      user_id { 2 }
+    end
+  end
+end

--- a/backend/spec/factories/users.rb
+++ b/backend/spec/factories/users.rb
@@ -1,0 +1,19 @@
+FactoryBot.define do
+  factory :user do
+    trait :current do
+      id { 1 }
+      login { "Example User 1" }
+      display_name { "Current User" }
+      user_access_token { "Bearer user_access_token_1" }
+      refresh_token { "refresh_token_1" }
+    end
+
+    trait :other do
+      id { 2 }
+      login { "Example User 2" }
+      display_name { "Other User" }
+      user_access_token { "Bearer user_access_token_2" }
+      refresh_token { "refresh_token_2" }
+    end
+  end
+end

--- a/backend/spec/requests/playlists_spec.rb
+++ b/backend/spec/requests/playlists_spec.rb
@@ -1,0 +1,153 @@
+require "rails_helper"
+
+RSpec.describe "Playlists", type: :request do
+  before do
+    @current_user = FactoryBot.create(:user, :current)
+    @other_user = FactoryBot.create(:user, :other)
+  end
+
+  describe "GET /playlists" do
+    before do
+      @my_playlist = FactoryBot.create(:playlist, :my_playlist)
+      @other_playlist = FactoryBot.create(:playlist, :other_playlist)
+    end
+
+    it "playlistの一覧を表示" do
+      get playlists_path
+      data = JSON.parse(response.body)
+      expect(response.status).to eq(200)
+      expect(data["meta"]["elementsCount"]).to be >= 1
+    end
+
+    it "title検索ができる" do
+      get playlists_path, params: { title: "マイ" }
+      data = JSON.parse(response.body)
+      data["playlists"].each do |playlist|
+        expect(playlist["title"]).to include("マイ")
+      end
+    end
+
+    it "作成者検索ができる" do
+      get playlists_path, params: { creator: @other_user.display_name }
+      data = JSON.parse(response.body)
+      data["playlists"].each do |playlist|
+        expect(playlist["creator_name"]).to include(@other_user.display_name)
+      end
+    end
+  end
+
+  describe "GET /playlists/:id" do
+    it "自分のプレイリストを表示できる" do
+      @my_playlist = FactoryBot.create(:playlist, :my_playlist)
+      get playlist_path(@my_playlist.slug)
+      data = JSON.parse(response.body)
+      expect(response.status).to eq(200)
+      expect(data["creator_name"]).to eq(@current_user.display_name)
+    end
+
+    it "他人のプレイリストを表示できる" do
+      @other_playlist = FactoryBot.create(:playlist, :other_playlist)
+      get playlist_path(@other_playlist.slug)
+      data = JSON.parse(response.body)
+      expect(response.status).to eq(200)
+      expect(data["creator_name"]).to eq(@other_user.display_name)
+    end
+  end
+
+  describe "POST /playlists" do
+    it "適切なuserAccessDigestとuserIdの組でplaylistを作成できる" do
+      expect {
+        post playlists_path, params: { title: "テスト用プレイリスト" }, headers: { "userAccessDigest": @current_user.convert_digest, "userId": @current_user.id }
+      }.to change(Playlist, :count).by(1)
+    end
+
+    it "不適切なuserAccessDigestのときにplaylistを作成できない" do
+      expect {
+        post playlists_path, params: { title: "テスト用プレイリスト" }, headers: { "userAccessDigest": @other_user.convert_digest, "userId": @current_user.id }
+      }.not_to change(Playlist, :count)
+    end
+  end
+
+  describe "PATCH /playlists/:id" do
+    it "自分のplaylistを更新できる" do
+      @my_playlist = FactoryBot.create(:playlist, :my_playlist)
+      patch playlist_path(@my_playlist.slug), params: { title: "新しいプレイリスト名" }, headers: { "userAccessDigest": @current_user.convert_digest, "userId": @current_user.id }
+      expect(response.status).to eq(201)
+      expect(@my_playlist.reload.title).to eq("新しいプレイリスト名")
+    end
+
+    it "他人のplaylistを更新できない" do
+      @other_playlist = FactoryBot.create(:playlist, :other_playlist)
+      patch playlist_path(@other_playlist.slug), params: { title: "新しいプレイリスト名" }, headers: { "userAccessDigest": @current_user.convert_digest, "userId": @current_user.id }
+      expect(response.status).to eq(403)
+      expect(@other_playlist.reload.title).not_to eq("新しいプレイリスト名")
+    end
+  end
+
+  describe "DELETE /playlists/:id" do
+    it "自分のplaylistを削除できる" do
+      @my_playlist = FactoryBot.create(:playlist, :my_playlist)
+      expect { delete playlist_path(@my_playlist.slug), headers: { "userAccessDigest": @current_user.convert_digest, "userId": @current_user.id } }.to change(Playlist, :count).by(-1)
+      expect(response.status).to eq(204)
+    end
+
+    it "他人のplaylistを削除できない" do
+      @other_playlist = FactoryBot.create(:playlist, :other_playlist)
+      expect { delete playlist_path(@other_playlist.slug), headers: { "userAccessDigest": @current_user.convert_digest, "userId": @current_user.id } }.not_to change(Playlist, :count)
+      expect(response.status).to eq(403)
+    end
+  end
+
+  describe "POST /playlists/:id/clips/:clip_id" do
+    before do
+      FactoryBot.create(:broadcaster, :tokikaze)
+      FactoryBot.create(:game, :lol)
+      @clip = FactoryBot.create(:clip, :tokikaze_top_clip)
+    end
+
+    it "自分のプレイリストにクリップを追加できる" do
+      @my_playlist = FactoryBot.create(:playlist, :my_playlist)
+      expect {
+        post clip_playlist_path(id: @my_playlist.slug, clip_id: @clip.slug),
+             headers: { "userAccessDigest": @current_user.convert_digest, "userId": @current_user.id }
+      }.to change { @my_playlist.clips.count }.by(1)
+      expect(response.status).to eq(201)
+    end
+
+    it "他人のプレイリストにクリップを追加できない" do
+      @other_playlist = FactoryBot.create(:playlist, :other_playlist)
+      expect {
+        post clip_playlist_path(id: @other_playlist.slug, clip_id: @clip.slug),
+             headers: { "userAccessDigest": @current_user.convert_digest, "userId": @current_user.id }
+      }.not_to change { @other_playlist.clips.count }
+      expect(response.status).to eq(403)
+    end
+  end
+
+  describe "DELETE /playlists/:id/clips/:clip_id" do
+    before do
+      FactoryBot.create(:broadcaster, :tokikaze)
+      FactoryBot.create(:game, :lol)
+      @clip = FactoryBot.create(:clip, :tokikaze_top_clip)
+    end
+
+    it "自分のプレイリストのクリップを削除できる" do
+      @my_playlist = FactoryBot.create(:playlist, :my_playlist)
+      @my_playlist.add(@clip)
+      expect {
+        delete clip_playlist_path(id: @my_playlist.slug, clip_id: @clip.slug),
+               headers: { "userAccessDigest": @current_user.convert_digest, "userId": @current_user.id }
+      }.to change { @my_playlist.clips.count }.by(-1)
+      expect(response.status).to eq(204)
+    end
+
+    it "他人のプレイリストのクリップを削除できる" do
+      @other_playlist = FactoryBot.create(:playlist, :other_playlist)
+      expect {
+        delete clip_playlist_path(id: @other_playlist.slug, clip_id: @clip.slug),
+               headers: { "userAccessDigest": @current_user.convert_digest, "userId": @current_user.id }
+      }.not_to change { @other_playlist.clips.count }
+      expect(response.status).to eq(403)
+    end
+  end
+end

--- a/backend/spec/system/broadcasters_spec.rb
+++ b/backend/spec/system/broadcasters_spec.rb
@@ -1,12 +1,18 @@
 require "rails_helper"
 
 RSpec.describe "Broadcasters", type: :system do
+  before do
+    driven_by(:rack_test)
+  end
+
   describe "#index" do
     it "broadcastersの一覧を取得できる" do
       visit broadcasters_path
       expect(page.status_code).to eq(200)
     end
+  end
 
+  describe "#create" do
     it "broadcaster_idからBroadcasterを作成できる" do
       expect {
         post broadcasters_path, params: { broadcaster_id: 807966915 }

--- a/backend/spec/system/games_spec.rb
+++ b/backend/spec/system/games_spec.rb
@@ -5,8 +5,10 @@ RSpec.describe "Games", type: :system do
     driven_by(:rack_test)
   end
 
-  it "Gameの一覧を取得できる" do
-    visit games_path
-    expect(page.status_code).to eq(200)
+  describe "#index" do
+    it "Gameの一覧を取得できる" do
+      visit games_path
+      expect(page.status_code).to eq(200)
+    end
   end
 end


### PR DESCRIPTION
## 実施タスク
PlaylistsControllerの作成

## 実施内容
- index, show, create, update, destroy, add_clip, remove_clipアクションを作成
- PlaylistSerializerの作成
- and_searchをplaylistとclip共通のメソッド化
- clipとplaylistのDBにsearch_keywordsというカラムを追加。これを使って検索ができるように変更

## その他 / 備考
APIモードのテストはSystemSpecではなく、RequestsSpecの方が良さそうなので、今までSyetemSpecで書いてきたものを修正していく。
