### PR TITLE
Watchページの作成とバックエンドの修正

### DIFF
--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::API
       user = User.find_by(id: user_id)
 
       # digestの情報が正しいかを確認
-      if user.authenticated?(digest)
+      if user&.authenticated?(digest)
         @current_user = user
       end
     end

--- a/backend/app/controllers/clips_controller.rb
+++ b/backend/app/controllers/clips_controller.rb
@@ -25,6 +25,7 @@ class ClipsController < ApplicationController
     header = { "Authorization" => ENV["APP_ACCESS_TOKEN"],  "Client-id" => ENV["CLIENT_ID"] }
     base_uri = "https://api.twitch.tv/helix/clips?broadcaster_id=#{broadcaster_id}&first=100"
     after = nil
+    view_count = 10000
 
     # 時間設定
     n = 300 # 何時間前からの情報を取得するか
@@ -70,8 +71,9 @@ class ClipsController < ApplicationController
           @clip = Clip.friendly.find(data["id"])
           @clip.update(view_count: data["view_count"])
         end
+        view_count = data["view_count"]
       end
-      break if after.nil? || after.empty?
+      break if after.nil? || after.empty? || view_count < 100
     end
     render status: :created
   end
@@ -151,9 +153,9 @@ class ClipsController < ApplicationController
 
       # 指定なし(視聴数が多い順)
       else
-        clips = clips.sort_by { |clip| clip.view_count }.reverse
-        ids = clips.map(&:id)
-        clips = Clip.in_order_of(:id, ids)
+        # clips = clips.sort_by { |clip| clip.view_count }.reverse
+        # ids = clips.map(&:id)
+        # clips = Clip.in_order_of(:id, ids)
       end
 
       @clips_all_page = clips

--- a/backend/app/controllers/playlists_controller.rb
+++ b/backend/app/controllers/playlists_controller.rb
@@ -86,6 +86,11 @@ class PlaylistsController < ApplicationController
       elsif params[:target] == "creator"
         Playlist.joins(:user).where(users: { display_name: params[:field] })
 
+      # creatorのloginNameでソート
+      elsif params[:target] == "creatorId"
+        Playlist.joins(:user).where(users: { id: params[:field] })
+        # User.find_by(id: params[:field]).playlists # TODO: 一致検索のとき、どっちの方が早いか確かめる
+
       # titleでソート
       elsif params[:target] == "title"
         and_search(params[:field], "title", Playlist)

--- a/backend/app/serializers/clip_serializer.rb
+++ b/backend/app/serializers/clip_serializer.rb
@@ -1,15 +1,19 @@
 class ClipSerializer < ActiveModel::Serializer
-  attributes %i[slug broadcaster_name creator_name game_name game_image language title view_count clip_created_at thumbnail_url duration search_keywords]
+  attributes %i[slug broadcaster_name broadcaster_image_url creator_name game_name game_image_url language title view_count clip_created_at thumbnail_url duration search_keywords]
 end
 
 def game_name
   self.game.name
 end
 
-def game_image
+def game_image_url
   self.game.box_art_url
 end
 
 def broadcaster_name
   self.broadcaster.name
+end
+
+def broadcaster_image_url
+  self.broadcaster.profile_image_url
 end

--- a/backend/app/serializers/playlist_serializer.rb
+++ b/backend/app/serializers/playlist_serializer.rb
@@ -1,5 +1,8 @@
 class PlaylistSerializer < ActiveModel::Serializer
-  attributes %i[slug title creator_name first_clip_thumbnail_url clips_count favorited favorites_count created_at search_keywords]
+  attributes %i[slug title creator_name first_clip_thumbnail_url clips_count favorited favorites_count created_at search_keywords clips]
+
+  # TODO: 使わないデータもかなり入っているので、Playlist内に追加するクリップ用のPlaylistClipSerializerを作成しても良い。
+  has_many :clips, serializer: ClipSerializer
 
   def initialize(object, options = {})
     super(object, options)

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -7,9 +7,9 @@ Rails.application.routes.draw do
         get "/favorited", to: "playlists#index_favorited"
       end
       member do
-        post "/cilips/:clip_id", to: "playlists#add_clip", as: "clip"
-        delete "/cilips/:clip_id", to: "playlists#remove_clip"
-        put "/cilips", to: "playlists#order_clips", as: "clips"
+        post "/clips/:clip_id", to: "playlists#add_clip", as: "clip"
+        delete "/clips/:clip_id", to: "playlists#remove_clip"
+        put "/clips", to: "playlists#order_clips", as: "clips"
         post :favorite, to: "playlists#favorite"
         delete :favorite, to: "playlists#unfavorite"
       end

--- a/backend/db/migrate/20240308123908_create_users.rb
+++ b/backend/db/migrate/20240308123908_create_users.rb
@@ -3,7 +3,7 @@ class CreateUsers < ActiveRecord::Migration[7.0]
     create_table :users, id: false do |t|
       t.column :id, 'BIGINT PRIMARY KEY'
       t.string :login
-      t.string :display_name
+      t.string :display_name, index: true
       t.string :profile_image_url
       t.string :user_access_token
       t.string :refresh_token

--- a/backend/db/migrate/20240308123926_create_broadcasters.rb
+++ b/backend/db/migrate/20240308123926_create_broadcasters.rb
@@ -3,7 +3,7 @@ class CreateBroadcasters < ActiveRecord::Migration[7.0]
     create_table :broadcasters, id: false do |t|
       t.column :id, 'BIGINT PRIMARY KEY'
       t.string :login
-      t.string :display_name
+      t.string :display_name, index: true
       t.string :profile_image_url
 
       t.timestamps

--- a/backend/db/migrate/20240308123944_create_games.rb
+++ b/backend/db/migrate/20240308123944_create_games.rb
@@ -2,7 +2,7 @@ class CreateGames < ActiveRecord::Migration[7.0]
   def change
     create_table :games, id: false do |t|
       t.column :id, 'BIGINT PRIMARY KEY'
-      t.string :name
+      t.string :name, index: true
       t.string :box_art_url
 
       t.timestamps

--- a/backend/db/migrate/20240308124002_create_clips.rb
+++ b/backend/db/migrate/20240308124002_create_clips.rb
@@ -1,19 +1,19 @@
 class CreateClips < ActiveRecord::Migration[7.0]
   def change
     create_table :clips do |t|
-      t.string :slug, unique: true
+      t.string :slug, unique: true, index: true
       t.references :broadcaster, null: false, foreign_key: true
       t.string :broadcaster_name
       t.integer :creator_id
       t.string :creator_name
       t.references :game, null: false, foreign_key: true
       t.string :language
-      t.string :title
-      t.datetime :clip_created_at
+      t.string :title, index: true
+      t.datetime :clip_created_at, index: true
       t.string :thumbnail_url
       t.float :duration
-      t.integer :view_count
-      t.string :search_keywords
+      t.integer :view_count, index: true
+      t.string :search_keywords, index: true
       t.integer :order, null: false, default: 1
 
       t.timestamps

--- a/backend/db/migrate/20240308124020_create_playlists.rb
+++ b/backend/db/migrate/20240308124020_create_playlists.rb
@@ -1,10 +1,10 @@
 class CreatePlaylists < ActiveRecord::Migration[7.0]
   def change
     create_table :playlists do |t|
-      t.string :slug, unique: true
-      t.string :title
+      t.string :slug, unique: true, index: true
+      t.string :title, index: true
       t.references :user, null: false, foreign_key: true
-      t.string :search_keywords
+      t.string :search_keywords, index: true
 
       t.timestamps
     end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -17,6 +17,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_08_124059) do
     t.string "profile_image_url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["display_name"], name: "index_broadcasters_on_display_name"
   end
 
   create_table "clips", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -38,6 +39,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_08_124059) do
     t.datetime "updated_at", null: false
     t.index ["broadcaster_id"], name: "index_clips_on_broadcaster_id"
     t.index ["game_id"], name: "index_clips_on_game_id"
+    t.index ["slug"], name: "index_clips_on_slug"
   end
 
   create_table "favorites", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -55,6 +57,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_08_124059) do
     t.string "box_art_url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_games_on_name"
   end
 
   create_table "playlist_clips", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -74,6 +77,9 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_08_124059) do
     t.string "search_keywords"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["search_keywords"], name: "index_playlists_on_search_keywords"
+    t.index ["slug"], name: "index_playlists_on_slug"
+    t.index ["title"], name: "index_playlists_on_title"
     t.index ["user_id"], name: "index_playlists_on_user_id"
   end
 
@@ -85,6 +91,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_08_124059) do
     t.string "refresh_token"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["display_name"], name: "index_users_on_display_name"
   end
 
   add_foreign_key "clips", "broadcasters"

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -6,10 +6,15 @@
   --header-background: #fffffe;
   --sidebar-background: #efeff1;
   --content-background: #f7f7f8;
+  --clip-background: lightgrey;
+  --link: #6246ea;
   --important: #6246ea;
+  --important-hover: #5236da;
+  --button2: #e7e7ea;
+  --button2-hover: #d7d7da;
   --headline: #2b2c34;
   --paragraph: #2b2c34;
-  --link: #6246ea;
+  --line: #ddd;
   --color-border: 43, 44, 52;
 }
 

--- a/frontend/src/app/lib/action.js
+++ b/frontend/src/app/lib/action.js
@@ -1,5 +1,7 @@
 'use server'
 
+import { cookies } from 'next/headers'
+
 // clipIdからBroadcasterのclipsをDBに追加
 export async function addClipInfo(state, formData) {
   async function createBroadcaster(clipId) {
@@ -82,6 +84,33 @@ export async function addClipInfo(state, formData) {
     return true
   } else {
     console.log('clipsデータの取得に失敗しました')
+    return false
+  }
+}
+
+// clipをplaylistに追加
+export async function addClipToPlaylist({ clipId, listId }) {
+  try {
+    const response = await fetch(
+      `${process.env.API_BASE_URL}/playlists/${listId}/clips/${clipId}`,
+      {
+        method: 'POST',
+        headers: {
+          userId: cookies().get('userId')?.value,
+          userAccessDigest: cookies().get('userAccessDigest')?.value,
+        },
+      },
+    )
+    if (!response.ok) {
+      throw new Error('playlistへのclipの追加に失敗しました')
+    }
+
+    // 出力
+    return true
+  } catch (error) {
+    console.log('playlistへのclipの追加に失敗しました')
+
+    // 出力
     return false
   }
 }

--- a/frontend/src/app/lib/data.js
+++ b/frontend/src/app/lib/data.js
@@ -1,5 +1,8 @@
 'use server'
 
+import { cookies } from 'next/headers'
+
+// queryから検索結果を取得
 export async function fetchResults(query) {
   try {
     // 準備
@@ -45,12 +48,90 @@ export async function fetchResults(query) {
 
     const data = await response.json()
 
+    // TODO
+    console.log(data['clips'][0])
+
     // 出力
     if (data.meta.elementCount == 0) return null
     else return data
   } catch (error) {
     throw new Error(error)
   }
+}
+
+// clipIdからclipDataを取得
+export async function fetchClipData({ clipId }) {
+  try {
+    const response = await fetch(
+      `${process.env.API_BASE_URL}/clips/${clipId}`,
+      {
+        method: 'GET',
+        headers: {
+          userId: cookies().get('userId')?.value,
+          userAccessDigest: cookies().get('userAccessDigest')?.value,
+        },
+      },
+    )
+
+    if (!response.ok) {
+      throw new Error('clipDataの取得に失敗しました')
+    }
+
+    const data = await response.json()
+
+    return data
+  } catch (error) {
+    console.log('clipDataの取得に失敗しました')
+  }
+}
+
+// listIdからlistDataを取得
+export async function fetchListData({ listId }) {
+  try {
+    const response = await fetch(
+      `${process.env.API_BASE_URL}/playlists/${listId}`,
+      {
+        method: 'GET',
+        headers: {
+          userId: cookies().get('userId')?.value,
+          userAccessDigest: cookies().get('userAccessDigest')?.value,
+        },
+      },
+    )
+
+    if (!response.ok) {
+      throw new Error('listDataの取得に失敗しました')
+    }
+
+    const data = await response.json()
+
+    return data
+  } catch (error) {
+    console.log('listDataの取得に失敗しました')
+  }
+}
+
+// myListsDataを取得
+export async function fetchMyListsData() {
+  try {
+    // TODO
+    console.log(
+      `${process.env.API_BASE_URL}/playlists?target=creatorId&field=${cookies().get('userId')?.value}`,
+    )
+
+    const response = await fetch(
+      `${process.env.API_BASE_URL}/playlists?target=creatorId&field=${cookies().get('userId')?.value}`,
+      {
+        method: 'GET',
+      },
+    )
+    const data = await response.json()
+
+    // TODO
+    console.log(data)
+
+    return data
+  } catch (error) {}
 }
 
 // broadcasterのすべての名前を取得

--- a/frontend/src/app/page.jsx
+++ b/frontend/src/app/page.jsx
@@ -1,3 +1,18 @@
+import Link from 'next/link'
+
 export default function Page() {
-  return <></>
+  return (
+    <>
+      <div>
+        <Link href="/watch?clip=RepleteBitterCormorantUWot-tyks4HB68CU1J7Kc&list=a90f7582-178c-4835-8141-dcec2df7286a">
+          葛葉をボコボコにする時風 list情報あり
+        </Link>
+      </div>
+      <div>
+        <Link href="/watch?clip=RepleteBitterCormorantUWot-tyks4HB68CU1J7Kc">
+          葛葉をボコボコにする時風 list情報なし
+        </Link>
+      </div>
+    </>
+  )
 }

--- a/frontend/src/app/search/page.jsx
+++ b/frontend/src/app/search/page.jsx
@@ -4,7 +4,7 @@ import { Suspense } from 'react'
 export default function Page({ searchParams }) {
   return (
     <>
-      <Suspense>
+      <Suspense fallback="loading...">
         <DataFetcher searchParams={searchParams} />
       </Suspense>
     </>

--- a/frontend/src/app/ui/search/pagination.jsx
+++ b/frontend/src/app/ui/search/pagination.jsx
@@ -43,8 +43,10 @@ export default function Pagination({
     <>
       <button onClick={() => handleClick(1)}>1</button>
       <span>...</span>
-      {pageNumbers.map((page) => (
-        <button onClick={() => handleClick(page)}>{page}</button>
+      {pageNumbers.map((page, index) => (
+        <button onClick={() => handleClick(page)} key={index}>
+          {page}
+        </button>
       ))}
       <span>...</span>
       <button onClick={() => handleClick(totalPages)}>{totalPages}</button>

--- a/frontend/src/app/ui/search/result/clip.jsx
+++ b/frontend/src/app/ui/search/result/clip.jsx
@@ -2,8 +2,8 @@ import styles from '@/app/ui/search/result/clip.module.css'
 import Link from 'next/link'
 
 export default function Clip({ result }) {
-  const game_image_url = result.game_image
-    ? result.game_image.replace('{width}', '240').replace('{height}', '480')
+  const game_image_url = result.game_image_url
+    ? result.game_image_url.replace('{width}', '240').replace('{height}', '480')
     : 'https://static-cdn.jtvnw.net/ttv-boxart/32982_IGDB-{width}x{height}.jpg' // 存在しないときは、不明のbox_artを入れてやる
 
   return (
@@ -42,10 +42,6 @@ export default function Clip({ result }) {
             <div className={styles.broadcaster}>{result.broadcaster_name}</div>
           </Link>
           <div className={styles.creator}>作成者: {result.creator_name}</div>
-          {/* <div className={styles.option}>
-            作成日: {result.clip_created_at.slice(0, 10)}
-          </div> */}
-          {/* <div>{result.slug}</div> */}
         </div>
       </div>
     </div>

--- a/frontend/src/app/ui/watch/broadcaster/broadcaster.jsx
+++ b/frontend/src/app/ui/watch/broadcaster/broadcaster.jsx
@@ -1,0 +1,21 @@
+import Link from 'next/link'
+import styles from '@/app/ui/watch/broadcaster/broadcaster.module.css'
+
+export default function Broadcaster({ imageUrl, name }) {
+  return (
+    <>
+      <Link href={`/search?type=clip&target=broadcaster&field=${name}`}>
+        <div className={styles.imageWrapper}>
+          <div className={styles.imageBackground}>
+            <img className={styles.image} src={imageUrl} alt={imageUrl} />
+          </div>
+        </div>
+      </Link>
+      <div className={styles.name}>
+        <Link href={`/search?type=clip&target=broadcaster&field=${name}`}>
+          {name}
+        </Link>
+      </div>
+    </>
+  )
+}

--- a/frontend/src/app/ui/watch/broadcaster/broadcaster.module.css
+++ b/frontend/src/app/ui/watch/broadcaster/broadcaster.module.css
@@ -1,0 +1,34 @@
+.imageWrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 80px;
+  height: 80px;
+
+  .imageBackground {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 70px;
+    height: 70px;
+    cursor: pointer;
+
+    .image {
+      border-radius: 100%;
+      border: 2px solid var(--link);
+      height: 100%;
+      width: 100%;
+      transition: all 0.05s;
+      box-sizing: content-box;
+    }
+
+    .image:hover {
+      border: 4px solid var(--link);
+    }
+  }
+}
+
+.name {
+  font-size: 18px;
+  font-weight: 600;
+}

--- a/frontend/src/app/ui/watch/data-fetcher.jsx
+++ b/frontend/src/app/ui/watch/data-fetcher.jsx
@@ -1,0 +1,21 @@
+import { fetchClipData, fetchListData, fetchMyListsData } from '@/app/lib/data'
+import Watch from '@/app/ui/watch/watch'
+
+export default async function DataFetcher({ searchParams }) {
+  const clipId = searchParams['clip']
+  const listId = searchParams['list']
+  const clipData = await fetchClipData({ clipId })
+  const listData = await fetchListData({ listId })
+  const myListsData = await fetchMyListsData()
+  // indexの計算は、次でやれば良さそう？
+  // myLibraryDataのfetchが必要そう？
+  return (
+    <>
+      <Watch
+        clipData={clipData}
+        listData={listData}
+        myListsData={myListsData}
+      />
+    </>
+  )
+}

--- a/frontend/src/app/ui/watch/info/detail/detail.jsx
+++ b/frontend/src/app/ui/watch/info/detail/detail.jsx
@@ -1,0 +1,16 @@
+import styles from '@/app/ui/watch/info/detail/detail.module.css'
+
+export default function Detail({ title, gameName, viewCount }) {
+  return (
+    <>
+      <div className={styles.top}>
+        <div className={styles.title}>{title}</div>
+      </div>
+      <div className={styles.bottom}>
+        <span className={styles.gameName}>{gameName}</span>
+        <span>・</span>
+        <span className={styles.viewCount}>視聴回数{viewCount}回</span>
+      </div>
+    </>
+  )
+}

--- a/frontend/src/app/ui/watch/info/detail/detail.module.css
+++ b/frontend/src/app/ui/watch/info/detail/detail.module.css
@@ -1,0 +1,23 @@
+.top {
+  .title {
+    font-size: 20px;
+    line-height: 24px;
+    font-weight: 600;
+  }
+}
+
+.bottom {
+  font-size: 15px;
+
+  .gameName {
+    color: var(--link);
+    cursor: pointer;
+  }
+  .gameName:hover {
+    text-decoration: underline;
+  }
+
+  .viewCount {
+    color: #555;
+  }
+}

--- a/frontend/src/app/ui/watch/info/operation/add-clip-to-playlist.jsx
+++ b/frontend/src/app/ui/watch/info/operation/add-clip-to-playlist.jsx
@@ -1,0 +1,61 @@
+'use client'
+
+import { useState } from 'react'
+import ReactModal from 'react-modal'
+import { addClipToPlaylist } from '@/app/lib/action'
+import styles from '@/app/ui/watch/info/operation/add-clip-to-playlist.module.css'
+import Playlist from '@/app/ui/watch/info/operation/playlist/playlist'
+
+export default function AddClipToPlaylist({ clipData, myListsData }) {
+  // modalの開閉状況
+  const [modalState, setModalState] = useState(false)
+
+  // modalを閉じる設定
+  function closeModal() {
+    setModalState(false)
+  }
+
+  // modalのスタイル
+  const modalStyles = {
+    overlay: {
+      zIndex: 200,
+    },
+    content: {
+      top: '50%',
+      left: '50%',
+      right: 'auto',
+      bottom: 'auto',
+      marginRight: '-50%',
+      transform: 'translate(-50%, -50%)',
+      maxWidth: '300px',
+      borderRadius: '6px',
+      padding: '12px 20px 12px 20px',
+    },
+  }
+
+  return (
+    <>
+      <button className={styles.add} onClick={() => setModalState(true)}>
+        <div className={styles.icon}>
+          <i className="far fa-plus-square"></i>
+        </div>
+        <div className={styles.char}>リストに追加</div>
+      </button>
+      <ReactModal
+        isOpen={modalState}
+        onRequestClose={() => setModalState(false)}
+        style={modalStyles}
+      >
+        <div className={styles.modal}>
+          <div className={styles.modalTitle}>クリップの保存先を選択</div>
+          <div className={styles.playlists}>
+            {myListsData.playlists.map((listData, index) => (
+              <Playlist listData={listData} clipData={clipData} key={index} />
+            ))}
+          </div>
+          <div className={styles.newPlaylist}>新しくプレイリストを追加</div>
+        </div>
+      </ReactModal>
+    </>
+  )
+}

--- a/frontend/src/app/ui/watch/info/operation/add-clip-to-playlist.module.css
+++ b/frontend/src/app/ui/watch/info/operation/add-clip-to-playlist.module.css
@@ -1,0 +1,50 @@
+.add {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 5px;
+  height: 32px;
+  padding: 0px 10px 0px 10px;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  font-weight: bold;
+  white-space: nowrap;
+  color: var(--paragraph);
+  background-color: var(--button2);
+
+  .icon {
+    display: flex;
+    align-items: center;
+    font-size: 16px;
+  }
+
+  .char {
+    font-size: 14px;
+  }
+}
+
+.add:hover {
+  background-color: var(--button2-hover);
+}
+
+.modal {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+
+  .modalTitle {
+    font-weight: 600;
+  }
+
+  .playlists {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    flex-wrap: nowrap;
+    gap: 3px;
+  }
+
+  .newPlaylist {
+  }
+}

--- a/frontend/src/app/ui/watch/info/operation/move-next-button.jsx
+++ b/frontend/src/app/ui/watch/info/operation/move-next-button.jsx
@@ -1,0 +1,20 @@
+import { useRouter } from 'next/navigation'
+import styles from '@/app/ui/watch/info/operation/moveButton.module.css'
+
+export default function MoveNextButton({ listData, index, autoplay }) {
+  const router = useRouter()
+  function moveNextClip(listData, index) {
+    const clipId = listData.clips[(index + 1) % listData.clips.length].slug
+    router.push(`?clip=${clipId}&list=${listData.slug}`)
+    autoplay.current = true
+  }
+
+  return (
+    <button
+      className={styles.moveButton}
+      onClick={() => moveNextClip(listData, index)}
+    >
+      次へ
+    </button>
+  )
+}

--- a/frontend/src/app/ui/watch/info/operation/move-previous-button.jsx
+++ b/frontend/src/app/ui/watch/info/operation/move-previous-button.jsx
@@ -1,0 +1,23 @@
+import { useRouter } from 'next/navigation'
+import styles from '@/app/ui/watch/info/operation/moveButton.module.css'
+
+export default function MovePreviousButton({ listData, index, autoplay }) {
+  const router = useRouter()
+  function movePreviousClip(listData, index) {
+    const clipId =
+      listData.clips[
+        (index + listData.clips.length - 1) % listData.clips.length
+      ].slug
+    router.push(`?clip=${clipId}&list=${listData.slug}`)
+    autoplay.current = true
+  }
+
+  return (
+    <button
+      className={styles.moveButton}
+      onClick={() => movePreviousClip(listData, index)}
+    >
+      前へ
+    </button>
+  )
+}

--- a/frontend/src/app/ui/watch/info/operation/moveButton.module.css
+++ b/frontend/src/app/ui/watch/info/operation/moveButton.module.css
@@ -1,0 +1,16 @@
+.moveButton {
+  height: 32px;
+  padding: 0px 30px 0px 30px;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: bold;
+  white-space: nowrap;
+  background-color: var(--important);
+  color: white;
+}
+
+.moveButton:hover {
+  background-color: var(--important-hover);
+}

--- a/frontend/src/app/ui/watch/info/operation/playlist/playlist.jsx
+++ b/frontend/src/app/ui/watch/info/operation/playlist/playlist.jsx
@@ -1,0 +1,20 @@
+import { addClipToPlaylist } from '@/app/lib/action'
+import styles from '@/app/ui/watch/info/operation/playlist/playlist.module.css'
+
+export default function Playlist({ listData, clipData }) {
+  async function add(listId, clipId) {
+    const status = await addClipToPlaylist({ clipId, listId })
+
+    if (status) {
+      console.log('クリップの追加に成功しました')
+    } else {
+      console.log('クリップの追加に失敗しました')
+    }
+  }
+
+  return (
+    <button onClick={() => add(listData.slug, clipData.slug)}>
+      <div className={styles.playlist}>{listData.title}</div>
+    </button>
+  )
+}

--- a/frontend/src/app/ui/watch/info/operation/playlist/playlist.module.css
+++ b/frontend/src/app/ui/watch/info/operation/playlist/playlist.module.css
@@ -1,0 +1,16 @@
+.playlist {
+  /* スクロールバーが出現 */
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  /* 省略してくれるが、左の空白が変 */
+  /* display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 1;
+  overflow: hidden; */
+}
+
+.playlist:hover {
+  text-decoration: underline;
+}

--- a/frontend/src/app/ui/watch/play/play.jsx
+++ b/frontend/src/app/ui/watch/play/play.jsx
@@ -1,0 +1,17 @@
+export default function Play({ twitchId, title, autoplay }) {
+  const baseUrl = 'https://clips.twitch.tv/embed?clip='
+
+  return (
+    <iframe
+      // className={styles.video}
+      id="twitchIframe"
+      title={title}
+      src={
+        baseUrl + twitchId + '&parent=localhost&autoplay=' + autoplay.current
+      }
+      allowFullScreen
+      width="100%"
+      height="100%"
+    ></iframe>
+  )
+}

--- a/frontend/src/app/ui/watch/playlist/clip/clip.jsx
+++ b/frontend/src/app/ui/watch/playlist/clip/clip.jsx
@@ -1,0 +1,41 @@
+'use client'
+
+import styles from '@/app/ui/watch/playlist/clip/clip.module.css'
+import clsx from 'clsx'
+import { useRouter } from 'next/navigation'
+
+export default function Clip({
+  clip,
+  index,
+  indexOfPlaylist,
+  listData,
+  autoplay,
+}) {
+  const router = useRouter()
+
+  function moveClip(clipId, listId) {
+    router.push(`?clip=${clipId}&list=${listId}`)
+    autoplay.current = true
+  }
+
+  return (
+    <div
+      onClick={() => moveClip(clip.slug, listData.slug)}
+      className={clsx(styles.clip, {
+        [styles.active]: index === indexOfPlaylist,
+      })}
+    >
+      <div className={styles.left}>
+        <img
+          src={clip.thumbnail_url}
+          alt={clip.thumbnail_url}
+          className={styles.image}
+        />
+      </div>
+      <div className={styles.right}>
+        <div className={styles.title}>{clip.title}</div>
+        <div className={styles.broadcasterName}>{clip.broadcaster_name}</div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/ui/watch/playlist/clip/clip.module.css
+++ b/frontend/src/app/ui/watch/playlist/clip/clip.module.css
@@ -1,0 +1,46 @@
+.clip {
+  display: flex;
+  flex-flow: row;
+  flex-wrap: nowrap;
+  gap: 5px;
+  padding-left: 10px;
+  padding-right: 10px;
+  cursor: pointer;
+
+  .left {
+    width: 180px;
+  }
+
+  .right {
+    width: 100%;
+    display: flex;
+    flex-flow: column;
+    /* flex-wrap: nowrap; */
+    gap: 10px;
+
+    .title {
+      font-weight: bold;
+      font-size: 14px;
+      line-height: 14px;
+      padding-top: 5px;
+
+      /* 2行までしか表示しない */
+      display: -webkit-box;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 2;
+      overflow: hidden;
+    }
+    .broadcasterName {
+      font-size: 12px;
+      line-height: 12px;
+    }
+  }
+}
+
+.clip:hover {
+  color: var(--link);
+}
+
+.active {
+  background-color: var(--clip-background);
+}

--- a/frontend/src/app/ui/watch/playlist/playlist.jsx
+++ b/frontend/src/app/ui/watch/playlist/playlist.jsx
@@ -1,0 +1,31 @@
+import Clip from '@/app/ui/watch/playlist/clip/clip'
+import styles from '@/app/ui/watch/playlist/playlist.module.css'
+
+export default function Playlist({ listData, indexOfPlaylist, autoplay }) {
+  return (
+    <div className={styles.playlist}>
+      {listData && (
+        <>
+          <div className={styles.top}>
+            <div className={styles.playlistName}>{listData.title}</div>
+            <div className={styles.favorite}>☆</div>
+          </div>
+          <div className={styles.bottom}>
+            <div className={styles.clips}>
+              {listData.clips.map((clip, index) => (
+                <Clip
+                  clip={clip}
+                  index={index}
+                  indexOfPlaylist={indexOfPlaylist}
+                  listData={listData}
+                  autoplay={autoplay}
+                  key={index}
+                />
+              ))}
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/app/ui/watch/playlist/playlist.module.css
+++ b/frontend/src/app/ui/watch/playlist/playlist.module.css
@@ -1,0 +1,34 @@
+.playlist {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding-top: 15px;
+  padding-bottom: 10px;
+  background-color: var(--background);
+  border: 1px solid #cccccc;
+  border-radius: 5px;
+
+  .top {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    padding-left: 15px;
+    padding-right: 15px;
+
+    .playlistName {
+      font-size: 18px;
+      font-weight: 600;
+    }
+
+    .favorite {
+    }
+  }
+
+  .bottom {
+    .clips {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+  }
+}

--- a/frontend/src/app/ui/watch/watch.jsx
+++ b/frontend/src/app/ui/watch/watch.jsx
@@ -1,0 +1,80 @@
+'use client'
+
+import { useRef } from 'react'
+import Play from '@/app/ui/watch/play/play'
+import Detail from '@/app/ui/watch/info/detail/detail'
+import MovePreviousButton from '@/app/ui/watch/info/operation/move-previous-button'
+import MoveNextButton from '@/app/ui/watch/info/operation/move-next-button'
+import Broadcaster from '@/app/ui/watch/broadcaster/broadcaster'
+import Playlist from '@/app/ui/watch/playlist/playlist'
+import styles from '@/app//ui/watch/watch.module.css'
+import AddClipToPlaylist from '@/app/ui/watch/info/operation/add-clip-to-playlist'
+
+export default function Watch({ clipData, listData, myListsData }) {
+  const autoplay = useRef('false')
+  const index = getIndex(listData, clipData)
+
+  function getIndex(listData, clipData) {
+    return listData?.clips.findIndex(
+      (clip) => String(clip.slug) === clipData.slug,
+    )
+  }
+
+  return (
+    <div className={styles.clip}>
+      <div className={styles.left}>
+        <div className={styles.play}>
+          <Play
+            twitchId={clipData.slug}
+            title={clipData.title}
+            autoplay={autoplay}
+          />
+        </div>
+        <div className={styles.info}>
+          <div className={styles.detail}>
+            <Detail
+              title={clipData.title}
+              gameName={clipData.game_name}
+              viewCount={clipData.view_count}
+            />
+          </div>
+          <div className={styles.operation}>
+            {listData && (
+              <>
+                <AddClipToPlaylist
+                  clipData={clipData}
+                  myListsData={myListsData}
+                />
+                <MovePreviousButton
+                  listData={listData}
+                  index={index}
+                  autoplay={autoplay}
+                />
+                <MoveNextButton
+                  listData={listData}
+                  index={index}
+                  autoplay={autoplay}
+                />
+              </>
+            )}
+          </div>
+        </div>
+        <div className={styles.broadcaster}>
+          <Broadcaster
+            imageUrl={clipData.broadcaster_image_url}
+            name={clipData.broadcaster_name}
+          />
+        </div>
+      </div>
+      <div className={styles.right}>
+        <div className={styles.playlist}>
+          <Playlist
+            listData={listData}
+            indexOfPlaylist={index}
+            autoplay={autoplay}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/ui/watch/watch.module.css
+++ b/frontend/src/app/ui/watch/watch.module.css
@@ -1,0 +1,50 @@
+.clip {
+  display: flex;
+  flex-wrap: nowrap;
+  flex-direction: row;
+  gap: 10px;
+  padding: 20px;
+
+  .left {
+    width: 100%;
+
+    .play {
+      width: 100%;
+      aspect-ratio: 40 / 19;
+    }
+
+    .info {
+      display: flex;
+      flex-wrap: nowrap;
+      flex-direction: row;
+      justify-content: space-between;
+      gap: 20px;
+      padding: 10px;
+      border-bottom: 1px solid var(--line);
+
+      .detail {
+        display: flex;
+        flex-direction: column;
+      }
+
+      .operation {
+        display: flex;
+        flex-direction: row;
+        gap: 20px;
+      }
+    }
+
+    .broadcaster {
+      display: flex;
+      flex-wrap: nowrap;
+      flex-direction: row;
+      align-items: center;
+      gap: 10px;
+      padding: 10px;
+    }
+  }
+
+  .right {
+    width: 550px;
+  }
+}

--- a/frontend/src/app/watch/page.jsx
+++ b/frontend/src/app/watch/page.jsx
@@ -1,0 +1,10 @@
+import DataFetcher from '@/app/ui/watch/data-fetcher'
+import { Suspense } from 'react'
+
+export default function Page({ searchParams }) {
+  return (
+    <Suspense fallback="loading...">
+      <DataFetcher searchParams={searchParams} />
+    </Suspense>
+  )
+}

--- a/frontend/src/package-lock.json
+++ b/frontend/src/package-lock.json
@@ -8,10 +8,12 @@
       "name": "front",
       "version": "0.1.0",
       "dependencies": {
+        "clsx": "^2.1.0",
         "js-cookie": "^3.0.5",
         "next": "14.1.3",
         "react": "^18",
         "react-dom": "^18",
+        "react-modal": "^3.16.1",
         "use-debounce": "^10.0.0"
       },
       "devDependencies": {
@@ -1149,6 +1151,14 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
+    "node_modules/clsx": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
+      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1939,6 +1949,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/exenv": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+      "integrity": "sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw=="
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -3223,7 +3238,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3714,7 +3728,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -3776,8 +3789,30 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "node_modules/react-modal": {
+      "version": "3.16.1",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.16.1.tgz",
+      "integrity": "sha512-VStHgI3BVcGo7OXczvnJN7yT2TWHJPDXZWyI/a0ssFNhGZWsPmB8cF0z33ewDXq4VfYMO1vXgiv/g8Nj9NDyWg==",
+      "dependencies": {
+        "exenv": "^1.2.0",
+        "prop-types": "^15.7.2",
+        "react-lifecycles-compat": "^3.0.0",
+        "warning": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "react": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18",
+        "react-dom": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18"
+      }
     },
     "node_modules/read-cache": {
       "version": "1.0.0",
@@ -4671,6 +4706,14 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/frontend/src/package.json
+++ b/frontend/src/package.json
@@ -9,10 +9,12 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "clsx": "^2.1.0",
     "js-cookie": "^3.0.5",
     "next": "14.1.3",
     "react": "^18",
     "react-dom": "^18",
+    "react-modal": "^3.16.1",
     "use-debounce": "^10.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## 実施タスク
Watchページの作成とバックエンドの修正 #14 

## 実施内容
### Watchページ作成
- Watchページのおおよその機能とスタイルを作成

### バックエンドの修正
- authenticatedメソッドの修正
- view_countが100以上のクリップのみをDBに追加するように変更
- loginIdでの検索を追加。検索では使わず、ログインユーザーのプレイリストデータ取得にのみ使用予定
- インデックスを追加
- routesのタイポ修正

## その他 / 備考
- お気に入り、Xで共有、プレイリストを作成して追加、クリップ追加後のSnackbarが未実装
- 現状、複数検索をするとエラーを吐くので注意。検索速度の話もあるので、また後程修正予定