### PR TITLE
Playlistの改善

### DIFF
--- a/frontend/src/app/lib/action.js
+++ b/frontend/src/app/lib/action.js
@@ -1,6 +1,7 @@
 'use server'
 
 import { cookies } from 'next/headers'
+import { redirect } from 'next/navigation'
 
 // clipIdからBroadcasterのclipsをDBに追加
 export async function addClipInfo(state, formData) {
@@ -172,7 +173,10 @@ export async function orderClipInPlaylist({ clipIds, listId }) {
 }
 
 // playlistを削除
-export async function deletePlaylist({ listId }) {
+export async function deletePlaylist({ listId, currentUserId }) {
+  // redirectするかの判定フラグ
+  let redirectRequested = false
+
   try {
     const response = await fetch(
       `${process.env.API_BASE_URL}/playlists/${listId}`,
@@ -190,8 +194,15 @@ export async function deletePlaylist({ listId }) {
     }
 
     console.log('playlistの削除に成功しました')
+    redirectRequested = true
   } catch (error) {
     console.log('playlistの削除に失敗しました')
+    redirectRequested = false
+  }
+
+  // redirect処理
+  if (redirectRequested) {
+    redirect(`/libraries/${currentUserId}`)
   }
 }
 

--- a/frontend/src/app/ui/libraries/playlists/playlist.jsx
+++ b/frontend/src/app/ui/libraries/playlists/playlist.jsx
@@ -48,15 +48,17 @@ export default function Playlist({ list }) {
             <div className={styles.creator}>作成者：{list.creator_name}</div>
           </div>
         </Link>
-        <div className={styles.bottom}>
-          <button className={styles.moveClip}>
-            <Link
-              href={`/watch?clip=${list.first_clip_slug}&list=${list.slug}`}
-            >
-              クリップを再生
-            </Link>
-          </button>
-        </div>
+        {list.clips_count != 0 && (
+          <div className={styles.bottom}>
+            <button className={styles.moveClip}>
+              <Link
+                href={`/watch?clip=${list.first_clip_slug}&list=${list.slug}`}
+              >
+                クリップを再生
+              </Link>
+            </button>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/frontend/src/app/ui/playlist/banner/banner.jsx
+++ b/frontend/src/app/ui/playlist/banner/banner.jsx
@@ -54,7 +54,10 @@ export default function Banner({ listData }) {
         </div>
         {cookies()?.get('userId').value == listData.creator_id && (
           <div className={styles.deleteButton}>
-            <DeleteButton listId={listData.slug} />
+            <DeleteButton
+              listId={listData.slug}
+              currentUserId={cookies()?.get('userId').value}
+            />
           </div>
         )}
       </div>

--- a/frontend/src/app/ui/playlist/banner/button/delete-button.jsx
+++ b/frontend/src/app/ui/playlist/banner/button/delete-button.jsx
@@ -3,13 +3,16 @@
 import styles from '@/app/ui/playlist/banner/button/delete-button.module.css'
 import { deletePlaylist } from '@/app/lib/action'
 
-export default function DeleteButton({ listId }) {
-  async function handleClick() {
-    const data = await deletePlaylist({ listId })
+export default function DeleteButton({ listId, currentUserId }) {
+  async function handleClick({ listId, currentUserId }) {
+    await deletePlaylist({ listId, currentUserId })
   }
 
   return (
-    <button className={styles.delete} onClick={() => handleClick({ listId })}>
+    <button
+      className={styles.delete}
+      onClick={() => handleClick({ listId, currentUserId })}
+    >
       <span className={styles.icon}>
         <i className="fa-regular fa-trash-can"></i>
       </span>

--- a/frontend/src/app/ui/playlist/clips/clips.jsx
+++ b/frontend/src/app/ui/playlist/clips/clips.jsx
@@ -7,6 +7,8 @@ import { SortableContext } from '@dnd-kit/sortable'
 import { useState } from 'react'
 import { useSensor, useSensors } from '@dnd-kit/core'
 import { orderClipInPlaylist } from '@/app/lib/action'
+import Cookies from 'js-cookie'
+import Undraggable from '@/app/ui/playlist/clips/undraggable'
 
 export default function Clips({ listData }) {
   const playlist = []
@@ -62,28 +64,46 @@ export default function Clips({ listData }) {
 
   return (
     <>
-      <DndContext
-        onDragOver={handleDragOver}
-        onDragEnd={() => handleDragEnd({ listId: listData.slug })}
-        sensors={sensors}
-      >
+      {Cookies?.get('userId') == listData.creator_id && (
+        <DndContext
+          onDragOver={handleDragOver}
+          onDragEnd={() => handleDragEnd({ listId: listData.slug })}
+          sensors={sensors}
+        >
+          <div className={styles.clips}>
+            <SortableContext items={items}>
+              {items.map((item, index) => (
+                <Draggable
+                  key={index}
+                  id={item}
+                  clip={listData.clips.find((clip) => clip.slug == item)}
+                  listId={listData.slug}
+                  setItems={setItems}
+                  items={items}
+                  setNewItems={setNewItems}
+                  creatorId={listData.creator_id}
+                />
+              ))}
+            </SortableContext>
+          </div>
+        </DndContext>
+      )}
+      {Cookies?.get('userId') != listData.creator_id && (
         <div className={styles.clips}>
-          <SortableContext items={items}>
-            {items.map((item, index) => (
-              <Draggable
-                key={index}
-                id={item}
-                clip={listData.clips.find((clip) => clip.slug == item)}
-                listId={listData.slug}
-                setItems={setItems}
-                items={items}
-                setNewItems={setNewItems}
-                creatorId={listData.creator_id}
-              />
-            ))}
-          </SortableContext>
+          {items.map((item, index) => (
+            <Undraggable
+              key={index}
+              id={item}
+              clip={listData.clips.find((clip) => clip.slug == item)}
+              listId={listData.slug}
+              setItems={setItems}
+              items={items}
+              setNewItems={setNewItems}
+              creatorId={listData.creator_id}
+            />
+          ))}
         </div>
-      </DndContext>
+      )}
     </>
   )
 }

--- a/frontend/src/app/ui/playlist/clips/undraggable.jsx
+++ b/frontend/src/app/ui/playlist/clips/undraggable.jsx
@@ -1,0 +1,26 @@
+import styles from '@/app/ui/playlist/clips/draggable.module.css'
+import Link from 'next/link'
+
+export default function Undraggable(props) {
+  return (
+    <>
+      <div className={`${styles.clip} ${styles.radius}`}>
+        <div className={styles.content}>
+          <div className={styles.middle}>
+            <div className={styles.image}>
+              <img className={styles.radius} src={props.clip.thumbnail_url} />
+            </div>
+          </div>
+          <Link href={`/watch?clip=${props.clip.slug}&list=${props.listId}`}>
+            <div className={styles.right}>
+              <p className={styles.title}>{props.clip.title}</p>
+              <p className={styles.broadcaster}>
+                {props.clip.broadcaster_name}
+              </p>
+            </div>
+          </Link>
+        </div>
+      </div>
+    </>
+  )
+}


### PR DESCRIPTION
## 実施タスク
Playlistの改善 #13 

## 実施内容
- 自分のプレイリストでないとき、ドラッグできないように変更
- プレイリスト削除後のリダイレクト処理を追加
- ライブラリの「クリップを視聴」ボタンを、プレイリスト内にクリップが存在する場合のみ表示するように変更

## その他 / 備考
なし
