### PR TITLE
cronの導入と定期実行タスクの作成

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -17,6 +17,13 @@ ARG RUBYGEMS_VERSION=3.4.6
 RUN gem update --system ${RUBYGEMS_VERSION} && \
     bundle install
 
+## cronをinstall
+RUN apt update && \
+    apt install -y cron
+
+## cronの起動
+RUN service cron start
+
 ## ホストのDockerFileと同じ階層のファイルをコンテナ内のapiディレクトリにコピー。マウント後なら変化なし。
 COPY . /api
 # -----------------------------------------------------------------------------------------------------

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -15,6 +15,7 @@ gem "dotenv-rails"
 gem "active_model_serializers"
 gem "friendly_id"
 gem "will_paginate"
+gem "whenever", require: false
 
 group :development, :test do
   gem "debug", platforms: %i[ mri mingw x64_mingw ]

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -93,6 +93,7 @@ GEM
     case_transform (0.2)
       activesupport
     childprocess (5.0.0)
+    chronic (0.10.2)
     concurrent-ruby (1.2.3)
     crass (1.0.6)
     date (3.3.4)
@@ -303,6 +304,8 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    whenever (1.0.0)
+      chronic (>= 0.6.3)
     will_paginate (4.0.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
@@ -336,6 +339,7 @@ DEPENDENCIES
   rubocop-rails
   solargraph
   tzinfo-data
+  whenever
   will_paginate
 
 RUBY VERSION

--- a/backend/config/application.rb
+++ b/backend/config/application.rb
@@ -14,6 +14,9 @@ module Api
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
 
+    # libを読み込む設定
+    config.paths.add 'lib', eager_load: true
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/backend/config/schedule.rb
+++ b/backend/config/schedule.rb
@@ -1,0 +1,50 @@
+# Rails.rootを使用するために必要。config/environment.rbを取り込む。
+# 記載しないとNameError: uninitialized constant #<Class:#<Whenever::JobList:...>>::Railsエラーが出る。
+require File.expand_path(File.dirname(__FILE__) + '/environment')
+
+# cronを実行する環境変数。
+# ENV['RAILS_ENV'] = nilの時:developmentを代入。
+rails_env = ENV['RAILS_ENV'] || :development
+
+# cronを実行する環境変数をセット
+set :environment, rails_env
+
+# ログの設定
+set :output, "/log/cron.log"
+
+# 定期実行
+every 3.hours do
+  begin
+    runner "Batch::Clips.update_all"
+  rescue
+    Rails.logger.error("clipsの登録に失敗しました")
+    raise e
+  end
+
+  begin
+    runner "Batch::Rankings.destroy"
+  rescue
+    Rails.logger.error("rakingsの削除に失敗しました")
+    raise e
+  end
+
+  begin
+    runner "Batch::Rankings.create"
+  rescue
+    Rails.logger.error("rakingsの作成に失敗しました")
+    raise e
+  end
+end
+
+
+# every 2.hours do
+#   command "/usr/bin/some_great_command"
+#   runner "MyModel.some_method"
+#   rake "some:great:rake:task"
+# end
+#
+# every 4.days do
+#   runner "AnotherModel.prune_old_records"
+# end
+
+# Learn more: http://github.com/javan/whenever

--- a/backend/lib/batch/clips.rb
+++ b/backend/lib/batch/clips.rb
@@ -1,0 +1,118 @@
+class Batch::Clips
+  def self.update_all
+    # broadcasters
+    @broadcasters = Broadcaster.where("language": "ja")
+
+    # 準備
+    header = { "Authorization" => ENV["APP_ACCESS_TOKEN"],  "Client-id" => ENV["CLIENT_ID"] }
+
+    # 時間設定
+    n = 12 # 何時間前からの情報を取得するか
+    current_datetime = DateTime.now
+    current_rfc3339 = current_datetime.strftime("%Y-%m-%dT%H:%M:%SZ")
+    n_hour_ago_datetime = current_datetime - Rational(n, 24)
+    n_hour_ago_rfc3339 = n_hour_ago_datetime.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    # すべてのBroadcasterで取得できるまでループ
+    @broadcasters.each do |broadcaster|
+      # broadcasterにまだクリップが1つもなかったら、全期間からのクリップ登録も行う
+      if broadcaster.clips.count == 0
+        create_all(broadcaster)
+      end
+
+      # 初期化
+      base_uri = "https://api.twitch.tv/helix/clips?broadcaster_id=#{broadcaster.id}&first=100"
+      after = nil
+
+      # データ取得が終わるまでループ
+      loop do
+        # n時間前までのクリップを取得
+        uri = after ? "#{base_uri}&after=#{after}&started_at=#{n_hour_ago_rfc3339}&ended_at=#{current_rfc3339}" : "#{base_uri}&started_at=#{n_hour_ago_rfc3339}&ended_at=#{current_rfc3339}"
+
+        # データ取得
+        res = request_get(header, uri)
+        after = res["pagination"]["cursor"]
+        res["data"].each do |data|
+          # game_idが空のときは、Undefinedに設定
+          data["game_id"] = 0 if data["game_id"] == ""
+
+          # gameが存在しなかったら作成
+          create_game(data["game_id"]) if !Game.find_by(id: data["game_id"])
+
+          # clipの主なデータをテーブルに保存
+          @clip = broadcaster.clips.build(slug: data["id"],
+                                           broadcaster_name: data["broadcaster_name"],
+                                           creator_id: data["creator_id"],
+                                           creator_name: data["creator_name"],
+                                           game_id: data["game_id"],
+                                           language: data["language"],
+                                           title: data["title"],
+                                           clip_created_at: data["created_at"],
+                                           thumbnail_url: data["thumbnail_url"],
+                                           duration: data["duration"],
+                                           view_count: data["view_count"])
+          if @clip.valid?
+            @clip.save
+          else
+            @clip = Clip.find_by(slug: data["id"])
+            @clip.update(view_count: data["view_count"])
+          end
+          data["view_count"]
+        end
+        break if after.nil? || after.empty?
+      end
+    end
+  end
+
+  private
+    def self.request_get(header, uri)
+      res = HTTP[header].get(uri)
+      JSON.parse(res.to_s)
+    end
+
+    def self.create_all(broadcaster)
+    # 準備
+    header = { "Authorization" => ENV["APP_ACCESS_TOKEN"],  "Client-id" => ENV["CLIENT_ID"] }
+    base_uri = "https://api.twitch.tv/helix/clips?broadcaster_id=#{broadcaster.id}&first=100"
+    after = nil
+    view_count = 10000 # この初期値は適当
+
+    # ループ
+    loop do
+      uri = after ? "#{base_uri}&after=#{after}" : "#{base_uri}"
+
+      # データ取得
+      res = request_get(header, uri)
+      after = res["pagination"]["cursor"]
+      res["data"].each do |data|
+        # game_idが空のときは、Undefinedに設定
+        data["game_id"] = 0 if data["game_id"] == ""
+
+        # gameが存在しなかったら作成
+        create_game(data["game_id"]) if !Game.find_by(id: data["game_id"])
+
+        # clipの主なデータをテーブルに保存
+        @clip = broadcaster.clips.build(slug: data["id"],
+                                        broadcaster_name: data["broadcaster_name"],
+                                        creator_id: data["creator_id"],
+                                        creator_name: data["creator_name"],
+                                        game_id: data["game_id"],
+                                        language: data["language"],
+                                        title: data["title"],
+                                        clip_created_at: data["created_at"],
+                                        thumbnail_url: data["thumbnail_url"],
+                                        duration: data["duration"],
+                                        view_count: data["view_count"])
+        if @clip.valid?
+          @clip.save
+        else
+          @clip = Clip.find_by(slug: data["id"])
+          @clip.update(view_count: data["view_count"])
+        end
+        view_count = data["view_count"]
+      end
+      break if after.nil? || after.empty? || view_count < 100
+    end
+    true
+  end
+end

--- a/backend/lib/batch/rankings.rb
+++ b/backend/lib/batch/rankings.rb
@@ -1,0 +1,73 @@
+class Batch::Rankings
+  # Rankingsの作成
+  def self.create
+    @bot = User.find(-1)
+    common_variable()
+
+    # Daily Top Clipsの作成
+    @bot.playlists.create(title: @daily_title)
+    @clips = get_top_clips("day")
+    @clips.each.with_index(2) do |clip, index|
+      @bot.playlists[0].clips << clip
+      @bot.playlists[0].playlist_clips.find_by(clip_id: clip.id).update(order: index)
+    end
+
+    # Weekly Top Clipsの作成
+    @bot.playlists.create(title: @weekly_title)
+    @clips = get_top_clips("week")
+    @clips.each.with_index(2) do |clip, index|
+      @bot.playlists[1].clips << clip
+      @bot.playlists[1].playlist_clips.find_by(clip_id: clip.id).update(order: index)
+    end
+
+    # Monthly Top Clipsの作成
+    @bot.playlists.create(title: @monthly_title)
+    @clips = get_top_clips("month")
+    @clips.each.with_index(2) do |clip, index|
+      @bot.playlists[2].clips << clip
+      @bot.playlists[2].playlist_clips.find_by(clip_id: clip.id).update(order: index)
+    end
+
+    puts "Rankingsの作成に成功しました"
+  end
+
+  # Rankingsの削除
+  def self.destroy
+    @bot = User.find(-1)
+    @bot.playlists.destroy_all
+    puts "Rankingsの削除に成功しました"
+  end
+
+  private
+    def self.common_variable
+      @daily_title = "Daily Top Clips"
+      @weekly_title = "Weekly Top Clips"
+      @monthly_title = "Monthly Top Clips"
+    end
+
+    def self.get_top_clips(term)
+      clips = Clip.all # すべてのクリップを取得
+      clips = apply_term(clips, term) # 期間で絞り込み
+      clips = clips.order(view_count: "DESC") # 視聴数順に並べ替え
+      clips.paginate(page: 1, per_page: 100) # 最初の100件を取得
+    end
+
+    def self.apply_term(clips, term)
+      # 1日
+      if term == "day"
+        clips.where(clip_created_at: Time.zone.yesterday..Time.zone.now)
+
+      # 1週間
+      elsif term == "week"
+        clips.where(clip_created_at: 1.week.ago..Time.zone.now)
+
+      # 1カ月
+      elsif term == "month"
+        clips.where(clip_created_at: 1.month.ago..Time.zone.now)
+
+      # 1年
+      elsif term == "year"
+        clips.where(clip_created_at: 1.year.ago..Time.zone.now)
+      end
+    end
+end


### PR DESCRIPTION
## 実施タスク
cronの導入と定期実行タスクの作成 #79 

## 実施内容
- cronをdev環境で使えるようにする
- clipデータのDBへの登録を定期実行できるようにする
- rankingの削除を定期実行できるようにする
- rankingの作成を定期実行できるようにする

## その他 / 備考
なし
