### PR TITLE
プレイリスト名の変更をキャンセルできない問題の修正

### DIFF
--- a/frontend/src/app/ui/common/display/playlists/new-playlist.jsx
+++ b/frontend/src/app/ui/common/display/playlists/new-playlist.jsx
@@ -8,7 +8,16 @@ export default function NewPlaylist() {
   const router = useRouter()
   async function handleClick() {
     const title = prompt('プレイリスト名', '')
+
+    // titleが空だったら変更しない
+    if (!title) {
+      return
+    }
+
+    // titleを使用してプレイリストを作成
     await createPlaylist({ title })
+
+    // ページのリロード
     router.refresh()
   }
 

--- a/frontend/src/app/ui/playlist/banner/banner.jsx
+++ b/frontend/src/app/ui/playlist/banner/banner.jsx
@@ -11,13 +11,20 @@ import Img from '@/app/ui/common/display/img/img'
 export default function Banner({ listData }) {
   return (
     <div className={styles.banner}>
-      <Link
-        href={`/watch?clip=${listData.first_clip_slug}&list=${listData.slug}`}
-      >
-        <div className={styles.image}>
-          <Img src={listData.first_clip_thumbnail_url} />
+      {listData.first_clip_slug && (
+        <Link
+          href={`/watch?clip=${listData.first_clip_slug}&list=${listData.slug}`}
+        >
+          <div className={styles.image}>
+            <Img src={listData.first_clip_thumbnail_url} />
+          </div>
+        </Link>
+      )}
+      {!listData.first_clip_slug && (
+        <div className={styles.noImage}>
+          <Img src="/no-image.png" />
         </div>
-      </Link>
+      )}
       <div className={styles.titleWrapper}>
         <EditPlaylistTitle
           listData={listData}

--- a/frontend/src/app/ui/playlist/banner/banner.module.css
+++ b/frontend/src/app/ui/playlist/banner/banner.module.css
@@ -24,6 +24,15 @@
     }
   }
 
+  .noImage {
+    width: 100%;
+    position: relative;
+
+    img {
+      border-radius: 10px;
+    }
+  }
+
   .image::before {
     content: "";
     position: absolute;

--- a/frontend/src/app/ui/playlist/banner/button/edit-playlist-title.jsx
+++ b/frontend/src/app/ui/playlist/banner/button/edit-playlist-title.jsx
@@ -11,12 +11,20 @@ export default function EditPlaylistTitle({ listData, currentUserId }) {
 
   async function handleClick({ listId }) {
     const newListTitle = prompt('新しいプレイリスト名', '')
+
+    // newListTitleが空だったら、変更しない
+    if (!newListTitle) {
+      return
+    }
+
+    // newListTitleに変更
     setListTitle(newListTitle)
     const isOk = await editPlaylistTitle({
       listId,
       newListTitle,
     })
 
+    // 変更に失敗したら、元のタイトルに戻す
     if (!isOk) {
       setListTitle(previousListTitle)
     }


### PR DESCRIPTION
## 実施タスク
プレイリスト名の変更をキャンセルできない問題の修正 #97 

## 実施内容
- titleがnilもしくは空文字のときは、作成・変更を行わないように修正
- clipが入っていないplaylistのbannerのimageのスタイルを修正

## その他 / 備考
なし
